### PR TITLE
added proper test for roundtrip

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,8 @@
    {meck, "0.8.2",
     {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}},
    {webmachine, ".*",
-    {git, "git://github.com/opscode/webmachine", {tag, "1.10.5.3"}}}
+    {git, "git://github.com/opscode/webmachine", {tag, "1.10.5.3"}}},
+   {proper, ".*", {git, "https://github.com/manopapad/proper.git" ,{branch, "master"}}}
   ]}.
 
 %% Set this to true if you will build OTP releases of this project via

--- a/test/hmac_api_lib_tests.erl
+++ b/test/hmac_api_lib_tests.erl
@@ -1,6 +1,7 @@
 -module(hmac_api_lib_tests).
 
 -include("src/hmac_api.hrl").
+-include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -author("Hypernumbers Ltd <gordon@hypernumbers.com>").
@@ -255,6 +256,46 @@ roundtrip_test() ->
                                          }),
                  match),
     ok.
+
+gen_method() ->
+  oneof([post, get, delete, put]).
+
+gen_content_type() ->
+  oneof(["application/json","text/html","text/plain","text/csv","text/css"]).
+
+gen_unicode_string() ->
+  ?SUCHTHAT(S, string(), lists:all(fun (C) -> xmerl_ucs:is_unicode(C) end, S)).
+
+prop_roundtrip() ->
+    %% non unicode strings will break xmerl_ucs:to_utf8:
+    % counterexample: {[],post,[97,112,112,108,105,99,97,116,105,111,110,47,106,115,111,110],[55296]}
+    ?FORALL(
+            {P,M,C, D}, {gen_unicode_string(), gen_method(), gen_content_type(), gen_unicode_string()},
+            begin
+              {PublicKey, PrivateKey} = hmac_api_lib:get_api_keypair(),
+              Method = M,
+              Path = P,
+              ContentType = C,
+              Date = D,
+              Headers = [{"date", Date}],
+              {_Name, Authorization} = hmac_api_lib:sign(PrivateKey, PublicKey, Method, Path, Headers,
+                                                          ContentType),
+              hmac_api_lib:validate(PrivateKey, PublicKey, Authorization,
+                                                 #hmac_signature{
+                                                    date = Date,
+                                                    method = Method,
+                                                    headers = Headers,
+                                                    resource = Path,
+                                                    contenttype = ContentType
+                                                   })
+                == match
+            end
+          ).
+
+roundtrip_qc_test_() ->
+  {timeout, 60000,
+    ?_assert(proper:quickcheck(prop_roundtrip(),
+                          [{to_file, user},{numtests,1000}]))}.
 
 paths_test() ->
     {PublicKey, PrivateKey} = hmac_api_lib:get_api_keypair(),


### PR DESCRIPTION
Generated counterexamples indicate that hmac_api_lib:validate/4
crashes when non-unicode strings (char 55296 and above) are passed to it.

Ran 1,000,000 tests against `hmac_api_lib:validate()` without failures (minus non-unicode issue mentioned above). Reduced to 1000 for standard eunit tests.
